### PR TITLE
Update Readme with xclip package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Like *Current Dir. path to clipboard* in _Notepad++_.
 
 
 ## Known Issues
+On Debian (Ubuntu) the _xclip_ package is not installed by default.
+
+To fix, run
+
+`sudo apt install xclip`
 
 ## Release Notes
 


### PR DESCRIPTION
On Ubuntu/Kubuntu the xclip package is needed for the node copy-paste module, but is not installed by default.

This fixed it on my Kubuntu OS and is [a documented problem with copy-paste](https://github.com/xavi-/node-copy-paste/issues/57)